### PR TITLE
Add DLRM Inference script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository captures important production workloads as simple easy to run be
 Get started with this repository by reviewing the documents in [docs](docs):
 
 - Running the benchmarks
-  - [DLRM Out-of-the-Box Training](docs/DLRM.md)
+  - [DLRM Out-of-the-Box Training and Inference](docs/DLRM.md)
 - Modifying the Benchmarks
 - [Benchmark Philosophy](docs/benchmark_philosophy.md)
 - [Adding new benchmarks](docs/adding_benchmarks.md)

--- a/benchmarks/run_dlrm_ootb_infer.sh
+++ b/benchmarks/run_dlrm_ootb_infer.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+printUsage() {
+  echo
+  echo "Usage: $(basename "$0") <options>"
+  echo
+  echo "Options:"
+  echo "  -h                      Prints this help."
+  echo "  -l <dir to save log>    Saves FB5 Log to specified directory in first argument."
+  echo "  -c <config file>        Runs the command in the config file instead of the default config."
+  echo
+  return 0
+}
+
+if [ "$1" == "" ]; then
+  printUsage
+  exit 0
+fi
+
+# Default values
+benchmark=dlrm
+implementation=ootb
+mode=eval
+config=tiny # default is tiny, proof of concept
+is_config=false
+
+while getopts "hl:c:" flag ;
+do
+  case "${flag}" in
+    h)
+      printUsage ; exit 0 ;;
+    l)
+      LOG_DIR=${OPTARG} ;;
+    c)
+      config=${OPTARG} ; is_config=true ;;
+  esac
+done
+
+LOGGER_FILE="${LOG_DIR}/${benchmark}_${implementation}_${mode}_${config}.log"
+
+echo "=== Launching FB5 ==="
+echo "Benchmark: ${benchmark}"
+echo "Implementation: ${implementation}"
+echo "Mode: ${mode}"
+echo "Config: ${config}"
+echo "Saving FB5 Logger File: ${LOGGER_FILE}"
+echo
+echo "Running Command:"
+
+if [ "$is_config" = true ]; then
+  config_flags=$(head -n 1 "${config}")
+  (set -x; python "${benchmark}/${implementation}/dlrm_s_pytorch.py" --inference-only ${config_flags} --fb5logger=${LOGGER_FILE} --fb5config=${config} 2>&1)
+else
+  (set -x; python "${benchmark}/${implementation}/dlrm_s_pytorch.py" --inference-only --mini-batch-size=64 --test-mini-batch-size=64 --test-num-workers=0 --data-generation=random --arch-mlp-bot=512-512-64 --arch-mlp-top=1024-1024-1024-1 --arch-sparse-feature-size=64 --arch-embedding-size=1000000-1000000-1000000-1000000-1000000-1000000-1000000-1000000 --num-indices-per-lookup=100 --numpy-rand-seed=727 --num-batches=200 --print-freq=20 --print-time --fb5logger=${LOGGER_FILE} --fb5config=${config} 2>&1)
+fi
+
+echo "=== Completed Run ==="

--- a/docs/DLRM.md
+++ b/docs/DLRM.md
@@ -72,6 +72,9 @@ Finished training it 1000/1000 of epoch 0, 46.44 ms/it, loss 0.082861
 === Completed Run ===
 ```
 
+### Inference
+You may also choose to run DLRM in Inference mode. To do so, follow the same steps as above using the `run_dlrm_ootb_infer.sh` script instead.
+
 ## Requirements
 pytorch-nightly
 


### PR DESCRIPTION
Similar to the run_dlrm_ootb_train.sh script,
add run_dlrm_ootb_infer.sh script. It can be used in
the same way as the training script. Update READMEs
to reflect that.