### PR TITLE
port xlmr to use gpu

### DIFF
--- a/benchmarks/run_xlmr_ootb_infer.sh
+++ b/benchmarks/run_xlmr_ootb_infer.sh
@@ -4,8 +4,8 @@
 benchmark=xlmr
 implementation=ootb
 mode=eval
-config=tiny # default is tiny, proof of concept
+config=fb-1dev-short
 LOG_DIR=results
 LOGGER_FILE="${LOG_DIR}/${benchmark}_${implementation}_${mode}_${config}.log"
 
-python "${benchmark}/${implementation}/xlmr.py" --inference-only ${config_flags} --logfile=${LOGGER_FILE} --fb5config=${config} --use-gpu
+python "${benchmark}/${implementation}/xlmr.py" --inference-only ${config_flags} --logfile=${LOGGER_FILE} --famconfig=${config} --use-gpu

--- a/benchmarks/xlmr/ootb/xlmr.py
+++ b/benchmarks/xlmr/ootb/xlmr.py
@@ -10,18 +10,18 @@ p = pathlib.Path(__file__).parent.resolve() / "../../../fb5logging"
 sys.path.append(fspath(p))
 from fb5logger import FB5Logger
 
-def time_sec(use_gpu):
+def time_ms(use_gpu):
     """
     Return time. If gpu is available, synchronize. 
     """
     if use_gpu:
         torch.cuda.synchronize()
-    return time.time()
+    return time.time_ns() * 1e-6
 
 def get_inference_model():
     fairseq_xlmr_large = torch.hub.load('pytorch/fairseq:main', 'xlmr.large') 
     fairseq_xlmr_large.eval()
-    fairseq_xlmr_large.half()
+    fairseq_xlmr_large.half() # TODO make this a command line arg
     # TODO use torchscript? jit/script this model?
     return fairseq_xlmr_large.model 
 
@@ -46,7 +46,7 @@ def init_argparse() -> argparse.ArgumentParser:
     )
     parser.add_argument("--logfile", type=str, default=None)
     parser.add_argument("--inference-only", action="store_true", default=False)
-    parser.add_argument("--fb5config", type=str, default="tiny")
+    parser.add_argument("--famconfig", type=str, default="tiny")
     parser.add_argument("--use-gpu", action="store_true", default=False) 
     return parser
 
@@ -63,9 +63,9 @@ def run():
     if args.logfile is not None:
         famlogger = FB5Logger(args.logfile)
         if(args.inference_only): 
-            famlogger.header("XLMR", "OOTB", "eval", args.fb5config)
+            famlogger.header("XLMR", "OOTB", "eval", args.famconfig)
         else:
-            famlogger.header("XLMR", "OOTB", "train", args.fb5config)
+            famlogger.header("XLMR", "OOTB", "train", args.famconfig)
             
     # prep model and data
     xlmr = None
@@ -83,14 +83,12 @@ def run():
 
     # benchmark! 
     if args.logfile is not None:
-        t_start_ms = time_sec(args.use_gpu) * 1000
-        famlogger.run_start(time_ms=t_start_ms)
+        famlogger.run_start(time_ms=time_ms(args.use_gpu))
 
     evaluate_simple(xlmr, data, famlogger=famlogger) 
 
     if args.logfile is not None:
-        t_stop_ms = time_sec(args.use_gpu) * 1000
-        famlogger.run_stop(data.shape[0], data.shape[1], time_ms=t_stop_ms)   
+        famlogger.run_stop(data.shape[0], data.shape[1], time_ms=time_ms(args.use_gpu))   
         # famlogger.record_batch_info(num_batches=data.shape[0], batch_size=data.shape[1])
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changed:
1. Added torch.cuda.synchronize for timing
2. Set data and xlmr model to use gpu (cuda)
3. Set alias of logger to famlogger in preparation for when fb5logger name changes to famlogger