### PR TITLE
Fix run_stop in logger to use time from argument

### DIFF
--- a/fb5logging/fb5logger.py
+++ b/fb5logging/fb5logger.py
@@ -25,7 +25,7 @@ class FB5Logger():
         """
         Naive implementation of current time.
         """
-        return round(time.time_ns() * 1e-6)
+        return time.time_ns() * 1e-6
 
     def log_line(self, log_info : dict, key : str):
         """


### PR DESCRIPTION
There was a bug where run_stop always uses time from its internal self._time_ms() function. Tested and this doesn't seem to affect XLM-R, but not sure if it affected other use cases. 

Also change internal time function to use time_ns for better accuracy. Also seems to not seriously affect anything, but better to be safe. 