### PR TITLE
Replace conditionals with no-op logger

### DIFF
--- a/benchmarks/dlrm/ootb/dlrm_s_pytorch.py
+++ b/benchmarks/dlrm/ootb/dlrm_s_pytorch.py
@@ -139,7 +139,7 @@ import pathlib
 from os import fspath
 p = pathlib.Path(__file__).parent.resolve() / "../../../fb5logging"
 sys.path.append(fspath(p))
-from fb5logger import FB5Logger
+from fb5logger import get_fb5logger
 import loggerconstants
 
 # quotient-remainder trick
@@ -1456,12 +1456,11 @@ def run():
             key=mlperf_logger.constants.INIT_START, log_all_ranks=True
         )
 
-    if args.fb5logger is not None:
-        fb5logger = FB5Logger(args.fb5logger)
-        if args.inference_only:
-            fb5logger.header("DLRM", "OOTB", "eval", args.fb5config, score_metric=loggerconstants.EXPS)
-        else:
-            fb5logger.header("DLRM", "OOTB", "train", args.fb5config, score_metric=loggerconstants.EXPS)
+    fb5logger = get_fb5logger(args.fb5logger)
+    if args.inference_only:
+        fb5logger.header("DLRM", "OOTB", "eval", args.fb5config, score_metric=loggerconstants.EXPS)
+    else:
+        fb5logger.header("DLRM", "OOTB", "train", args.fb5config, score_metric=loggerconstants.EXPS)
 
     if args.weighted_pooling is not None:
         if args.qr_flag:
@@ -2050,8 +2049,7 @@ def run():
         args.enable_profiling, use_cuda=use_gpu, record_shapes=True
     ) as prof:
 
-        if args.fb5logger is not None:
-            fb5logger.run_start()
+        fb5logger.run_start()
 
         if not args.inference_only:
             k = 0
@@ -2383,8 +2381,7 @@ def run():
                 use_gpu,
             )
 
-    if args.fb5logger is not None:
-        fb5logger.run_stop(nbatches, args.mini_batch_size)
+    fb5logger.run_stop(nbatches, args.mini_batch_size)
 
     # profiling
     if args.enable_profiling:

--- a/benchmarks/dlrm/ubench/dlrm_ubench_train_driver.py
+++ b/benchmarks/dlrm/ubench/dlrm_ubench_train_driver.py
@@ -17,7 +17,7 @@ import pytorch_linear as klinear
 # FB5 Logger
 p = pathlib.Path(__file__).parent.resolve() / "../../../fb5logging"
 sys.path.append(fspath(p))
-from fb5logger import FB5Logger
+from fb5logger import get_fb5logger
 import loggerconstants
 
 if __name__ == "__main__":
@@ -54,16 +54,14 @@ if __name__ == "__main__":
     print("Steps = ", args.steps, " warmups = ", args.warmups)
 
     #fb5 logging header
-    if args.fb5logger is not None:
-        fb5logger = FB5Logger(args.fb5logger)
+    fb5logger = get_fb5logger(args.fb5logger)
 
     if args.kernel == 'emb':
         print("with emb dataset ", args.dataset)
         global_bytes = 0
         global_elap = 0
-        if args.fb5logger is not None:
-            fb5logger.header("DLRM", "UBENCH", "train", args.kernel + "_" + args.dataset, score_metric=loggerconstants.GBPS)
-            fb5logger.run_start()
+        fb5logger.header("DLRM", "UBENCH", "train", args.kernel + "_" + args.dataset, score_metric=loggerconstants.GBPS)
+        fb5logger.run_start()
         if args.dataset == 'A':
             run_dataset = dataset.emb_A
         elif args.dataset == 'B':
@@ -82,16 +80,14 @@ if __name__ == "__main__":
             total_bytes /= 1.0e6
             global_bytes += total_bytes
             global_elap += elap
-        if args.fb5logger is not None:
-            extra_metadata={"GB/s": global_bytes / global_elap / 1.0e3, "ELAP": global_elap, "BYTES": global_bytes}
-            fb5logger.run_stop(args.steps, batch, extra_metadata=extra_metadata)
+        extra_metadata={"GB/s": global_bytes / global_elap / 1.0e3, "ELAP": global_elap, "BYTES": global_bytes}
+        fb5logger.run_stop(args.steps, batch, extra_metadata=extra_metadata)
     else:
         print("with linear dataset ", args.dataset, ", Data type: ", args.dtype)
         global_flops = 0
         global_elap = 0
-        if args.fb5logger is not None:
-            fb5logger.header("DLRM", "UBENCH", "train", args.kernel + "_" + args.dataset, score_metric=loggerconstants.TFPS)
-            fb5logger.run_start()
+        fb5logger.header("DLRM", "UBENCH", "train", args.kernel + "_" + args.dataset, score_metric=loggerconstants.TFPS)
+        fb5logger.run_start()
         if args.dataset == 'A':
             run_dataset = dataset.mlp_A
         elif args.dataset == 'small':
@@ -117,6 +113,5 @@ if __name__ == "__main__":
             flops *= 6
             global_flops += flops
             global_elap += elap
-        if args.fb5logger is not None:
-            extra_metadata={"TF/s": global_flops / global_elap / 1.0e12, "ELAP": global_elap, "FLOPS": global_flops}
-            fb5logger.run_stop(args.steps, batch_size, extra_metadata=extra_metadata)
+        extra_metadata={"TF/s": global_flops / global_elap / 1.0e12, "ELAP": global_elap, "FLOPS": global_flops}
+        fb5logger.run_stop(args.steps, batch_size, extra_metadata=extra_metadata)

--- a/benchmarks/xlmr/ootb/xlmr.py
+++ b/benchmarks/xlmr/ootb/xlmr.py
@@ -8,37 +8,37 @@ import pathlib
 from os import fspath
 p = pathlib.Path(__file__).parent.resolve() / "../../../fb5logging"
 sys.path.append(fspath(p))
-from fb5logger import FB5Logger
+from fb5logger import get_fb5logger
 
 def time_ms(use_gpu):
     """
-    Return time. If gpu is available, synchronize. 
+    Return time. If gpu is available, synchronize.
     """
     if use_gpu:
         torch.cuda.synchronize()
     return time.time_ns() * 1e-6
 
 def get_inference_model():
-    fairseq_xlmr_large = torch.hub.load('pytorch/fairseq:main', 'xlmr.large') 
+    fairseq_xlmr_large = torch.hub.load('pytorch/fairseq:main', 'xlmr.large')
     fairseq_xlmr_large.eval()
     fairseq_xlmr_large.half() # TODO make this a command line arg
     # TODO use torchscript? jit/script this model?
-    return fairseq_xlmr_large.model 
+    return fairseq_xlmr_large.model
 
 def generate_inference_data(nbatches=100, batchsize=64, seq_length=64, vocab_size=1000):
     shape = (nbatches, batchsize, seq_length)
     data = torch.rand(shape) * vocab_size
     data = data.int()
     return data
-    
-def evaluate_simple(model, input_data, famlogger=None):
+
+def evaluate_simple(model, input_data, fb5logger=None):
     """
     Run data through the model
     """
     for batch in input_data:
-        famlogger.batch_start()
+        fb5logger.batch_start()
         output = model(batch)
-        famlogger.batch_stop()
+        fb5logger.batch_stop()
 
 def init_argparse() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -47,7 +47,7 @@ def init_argparse() -> argparse.ArgumentParser:
     parser.add_argument("--logfile", type=str, default=None)
     parser.add_argument("--inference-only", action="store_true", default=False)
     parser.add_argument("--famconfig", type=str, default="tiny")
-    parser.add_argument("--use-gpu", action="store_true", default=False) 
+    parser.add_argument("--use-gpu", action="store_true", default=False)
     return parser
 
 def run():
@@ -60,36 +60,33 @@ def run():
         device = torch.device("cuda", 0)
 
     # prep logger
-    if args.logfile is not None:
-        famlogger = FB5Logger(args.logfile)
-        if(args.inference_only): 
-            famlogger.header("XLMR", "OOTB", "eval", args.famconfig)
-        else:
-            famlogger.header("XLMR", "OOTB", "train", args.famconfig)
-            
+    fb5logger = get_fb5logger(args.logfile)
+    if(args.inference_only):
+        fb5logger.header("XLMR", "OOTB", "eval", args.famconfig)
+    else:
+        fb5logger.header("XLMR", "OOTB", "train", args.famconfig)
+
     # prep model and data
     xlmr = None
     data = None
-    if(args.inference_only): 
+    if(args.inference_only):
         data = generate_inference_data()
         xlmr = get_inference_model()
     else:
         pass # TODO train side
 
     # use gpu
-    if args.use_gpu: 
+    if args.use_gpu:
         data = data.to(device)
         xlmr = xlmr.to(device)
 
-    # benchmark! 
-    if args.logfile is not None:
-        famlogger.run_start(time_ms=time_ms(args.use_gpu))
+    # benchmark!
+    fb5logger.run_start(time_ms=time_ms(args.use_gpu))
 
-    evaluate_simple(xlmr, data, famlogger=famlogger) 
+    evaluate_simple(xlmr, data, fb5logger=fb5logger)
 
-    if args.logfile is not None:
-        famlogger.run_stop(0, 0, time_ms=time_ms(args.use_gpu))    
-        famlogger.record_batch_info(num_batches=data.shape[0], batch_size=data.shape[1])
+    fb5logger.run_stop(0, 0, time_ms=time_ms(args.use_gpu))
+    fb5logger.record_batch_info(num_batches=data.shape[0], batch_size=data.shape[1])
 
 if __name__ == "__main__":
     run()

--- a/fb5logging/fb5logger.py
+++ b/fb5logging/fb5logger.py
@@ -1,9 +1,31 @@
-import logging
 import os
 import sys
 import json
 import time
 import loggerconstants as constants
+
+def get_fb5logger(log_file_path = None):
+    t = Nop() if log_file_path is None else FB5Logger
+    return t(log_file_path)
+
+class Nop:
+    def __init__(self):
+        pass
+
+    def __getattr__(self, attr):
+        return Nop()
+
+    def __call__(self, *args, **kwargs):
+        return Nop()
+
+    def __enter__(self):
+        return Nop()
+
+    def __exit__(self):
+        pass
+
+    def __repr__(self):
+        return "Logger is disabled. fb5logger.get_fb5logger was not passed a file path."
 
 # TODO: change name to FAMLogger
 class FB5Logger():
@@ -30,19 +52,19 @@ class FB5Logger():
 
     def log_line(self, log_info : dict, key : str):
         """
-        Log a line with a dict of arbitrary form for the data and a string key. 
+        Log a line with a dict of arbitrary form for the data and a string key.
         """
         log_info['key'] = key
         self._dump_json(log_info)
 
     def header(self, benchmark_name, implementation_name, mode, config_name, score_metric=constants.EXPS):
         """
-        Required for every log. Describes what the benchmark is. 
+        Required for every log. Describes what the benchmark is.
         """
         header_dict = {
-            "benchmark": benchmark_name, 
-            "implementation": implementation_name, 
-            "mode": mode, 
+            "benchmark": benchmark_name,
+            "implementation": implementation_name,
+            "mode": mode,
             "config": config_name,
             "score_metric": score_metric}
         self.log_line(header_dict, constants.HEADER)
@@ -59,7 +81,7 @@ class FB5Logger():
     # TODO: remove batch info args and migrate to record_batch_info
     def run_stop(self, num_batches, batch_size, extra_metadata = None, time_ms = None):
         """
-        Records end of logging and any required data. 
+        Records end of logging and any required data.
         """
         if(time_ms is None):
             time_ms = self._time_ms()
@@ -73,7 +95,7 @@ class FB5Logger():
         self.log_line(batch_size_dict, constants.BATCH_SIZE)
         nbatches_dict = {"num_batches": num_batches}
         self.log_line(nbatches_dict, constants.NUM_BATCHES)
-    
+
     def batch_start(self, time_ms = None):
         """
         Marks beginning of the model processing a batch

--- a/fb5logging/test_mllog.py
+++ b/fb5logging/test_mllog.py
@@ -1,15 +1,15 @@
-from fb5logger import FB5Logger
+from fb5logger import get_fb5logger
 import time
 
 
 def dummy_example():
   """Example usage of fb5logger"""
 
-  logger = FB5Logger("results/example_simple.log") # file to write to. works only with .log
+  logger = get_fb5logger("results/example_simple.log") # file to write to. works only with .log
   logger.header("DLRM", "OOTB", "train", "small") # benchmark, implementation, mode, config
 
-  logger.run_start() 
-  time.sleep(1) # whatever benchmark here. 
+  logger.run_start()
+  time.sleep(1) # whatever benchmark here.
   logger.run_stop(100, 32) # num_batches, batch_size
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lightly recommending these changes. I think a no-op in place of many conditionals is easier on the eye, easier to maintain, and less error prone. (See screenshot below).  Additionally, the get_fb5logger function added in this PR was influenced by Python 3's logging.getLogger() function.  The python docs recommend never instantiating their logger directly, in passionate language: "Note that Loggers should NEVER be instantiated directly, but always through the module-level function[.]" https://docs.python.org/3/library/logging.html.  The reason they provide is so getLogger function calls with identical arguments passed receive the same Logger object.  That reason isn't applicable to us as it doesn't impact functionality whether the same logger object is returned; we aren't requesting the same logger object twice in the same benchmark run.  But resembling a known pattern is usually a benefit more than a drawback.

<img width="794" alt="Screen Shot 2021-10-21 at 11 35 06 PM" src="https://user-images.githubusercontent.com/19678629/138586409-9261b1a3-93de-4425-84f1-788e6a56b83b.png">
