### PR TITLE
add dlrm inf batch latency and migrate it to bmlogger

### DIFF
--- a/benchmarks/dlrm/ootb/dlrm_s_pytorch.py
+++ b/benchmarks/dlrm/ootb/dlrm_s_pytorch.py
@@ -2516,3 +2516,4 @@ def run():
 
 if __name__ == "__main__":
     run()
+    

--- a/benchmarks/dlrm/ootb/dlrm_s_pytorch.py
+++ b/benchmarks/dlrm/ootb/dlrm_s_pytorch.py
@@ -2516,4 +2516,3 @@ def run():
 
 if __name__ == "__main__":
     run()
-    


### PR DESCRIPTION
1. Migrate DLRM to bmlogger away from fb5logger
2. Add dlrm inference batch latency

Tested with:
gpurun ./run_dlrm_ootb_infer.sh -l results
gpurun ./run_dlrm_ootb_train.sh -l results