### PR TITLE
Update XLMR quality and restructure file structure

### DIFF
--- a/benchmarks/xlmr/.gitignore
+++ b/benchmarks/xlmr/.gitignore
@@ -1,0 +1,2 @@
+*.png
+test_xlmr.py

--- a/benchmarks/xlmr/ootb/xlmr.py
+++ b/benchmarks/xlmr/ootb/xlmr.py
@@ -43,15 +43,12 @@ def inference(xlmr, x_l, device=None, logger=None):
     if logger is None:
         logger = get_bmlogger() #No op logger
 
-    i = 0
     for x in x_l:
         logger.batch_start()
         if device:
             x = x.to(device) 
         # xlmr.model.encoder.sentence_encoder(x)['encoder_out'][-1] # equivalent
-        i += 1
-        y_pred = xlmr.extract_features(x) 
-        del x
+        y_pred = xlmr.extract_features(data) 
         logger.batch_stop(time_ms=time_ms(device is not None))
 
 def train(xlmr, x_l, y_true_l, device=None, logger=None):
@@ -98,9 +95,6 @@ def generate_dataset(num_batches, batch_size, vocab_size, inference_only, seqlen
         # TODO: Use half kwarg to generate half input data when appropriate
         x, y = xlmr_data.generate_ml_sample(batchsize=batch_size, seq_length=seq_length_arg, vocab_size=vocab_size, get_y_true=get_y_true_arg)
         return x, y
-    
-    if(num_batches == 0):
-        return []
 
     X_data = []
     Y_data = []

--- a/benchmarks/xlmr/ootb/xlmr.py
+++ b/benchmarks/xlmr/ootb/xlmr.py
@@ -48,7 +48,7 @@ def inference(xlmr, x_l, device=None, logger=None):
         if device:
             x = x.to(device) 
         # xlmr.model.encoder.sentence_encoder(x)['encoder_out'][-1] # equivalent
-        y_pred = xlmr.extract_features(data) 
+        y_pred = xlmr.extract_features(x) 
         logger.batch_stop(time_ms=time_ms(device is not None))
 
 def train(xlmr, x_l, y_true_l, device=None, logger=None):

--- a/benchmarks/xlmr/ootb/xlmr_data.py
+++ b/benchmarks/xlmr/ootb/xlmr_data.py
@@ -1,0 +1,68 @@
+import torch
+import numpy as np
+import xlmr_utils
+"""
+Data generation for XLMR benchmark
+"""
+
+def sample_sequence_length(query_percentile = None, seq_len_dist=None, seq_len_max=float('inf')):
+    # TODO This kind of code probably exists somewhere? Fun to code but find a replacement.
+    # TODO Benchmark may OOM stochastically - reduce it
+    """
+    Given a percentile, gives the corresponding sequence length based on seq len distribution.
+    If percentile is none, percentile is randomly generated.
+
+    Expects 
+    query_percentile : float in range [0, 1]
+    seq_len_dist : dict with float keys in range [0, 1] and int vals in range [1, positive inf]
+    seq_len_max : int in range [1, positive inf]
+    """
+    def enforce_bounds(val, min_val, max_val):
+        """
+        Enforces max and min val on the value
+        """
+        val = min(val, max_val)
+        val = max(val, min_val)
+        return val
+
+    if(query_percentile is None):
+        query_percentile = np.random.rand()
+
+    if(seq_len_dist is None): # default is to always return 64 seq len
+        seq_len_dist = {
+            1 : 64,
+            0 : 64,
+        }
+
+    sorted_percentiles = sorted(seq_len_dist)
+    sorted_seqlen = [seq_len_dist[sorted_percentiles[i]] for i in range(len(sorted_percentiles))]
+
+    seq_length_sample = xlmr_utils.query_from_percentile_distribution(query_percentile, sorted_percentiles, sorted_seqlen)
+    seq_length_sample = int(seq_length_sample)
+    seq_length_sample = enforce_bounds(seq_length_sample, 1, seq_len_max)
+    return seq_length_sample
+
+def generate_inputs(batchsize, seq_length, vocab_size, is_half=False):
+    shape = (batchsize, seq_length)
+    x = torch.rand(shape) * vocab_size
+    x = x.int()
+    if is_half:
+        x = x.half()
+    return x
+
+def generate_outputs(batchsize, seq_length, output_embed_size):
+    shape = (batchsize, seq_length, output_embed_size)
+    y = torch.rand(shape)
+    return y 
+
+def generate_ml_sample(batchsize=64, seq_length=64, vocab_size=250000, get_y_true=True, is_half=False):
+    """
+    Generates data for XLMR benchmark
+    """
+    x = generate_inputs(batchsize, seq_length, vocab_size, is_half=is_half)
+    y = torch.tensor([])
+    if(get_y_true):
+        output_embed_size = 1024
+        y = generate_outputs(batchsize, seq_length, output_embed_size)
+        
+    return x, y

--- a/benchmarks/xlmr/ootb/xlmr_data.py
+++ b/benchmarks/xlmr/ootb/xlmr_data.py
@@ -2,7 +2,7 @@ import torch
 import numpy as np
 import xlmr_utils
 """
-Data generation for XLMR benchmark
+Data generation for XLM-R benchmark
 """
 
 def sample_sequence_length(query_percentile = None, seq_len_dist=None, seq_len_max=float('inf')):

--- a/benchmarks/xlmr/ootb/xlmr_parser.py
+++ b/benchmarks/xlmr/ootb/xlmr_parser.py
@@ -2,7 +2,7 @@ import argparse
 import json
 
 """
-Parse inputs for the XLMR benchmark
+Parse inputs for the XLM-R benchmark
 """
 
 def dict_serialize(seqlen_dist_dict):

--- a/benchmarks/xlmr/ootb/xlmr_parser.py
+++ b/benchmarks/xlmr/ootb/xlmr_parser.py
@@ -5,13 +5,24 @@ import json
 Parse inputs for the XLMR benchmark
 """
 
-def parse_seqlen_dist(seqlen_dist_str):
+def dict_serialize(seqlen_dist_dict):
+    """
+    dict->str
+    Turns {1:'a',2:'b'}->"[[1,'a'],[2,'b']]"
+    Why? Because this format plays nice with shell script that runs xlmr_bench. 
+    Avoids curly braces and spaces that makes shell script str input unhappy. 
+    """
+    seqlen_dist_lst = list(seqlen_dist_dict.items())
+    seqlen_dist_str = json.dumps(seqlen_dist_lst)
+    seqlen_dist_str = seqlen_dist_str.replace(" ", "") # remove spaces
+    return seqlen_dist_str
+
+def dict_deserialize(seqlen_dist_str):
+    """
+    str->dict 
+    """
     seqlen_dist_json = json.loads(seqlen_dist_str)
-
-    # assert that it is in the right format (percentiles and integers)
-
-    return seqlen_dist_json
-
+    return dict(seqlen_dist_json)
 
 def init_argparse() -> argparse.ArgumentParser:
     """

--- a/benchmarks/xlmr/ootb/xlmr_parser.py
+++ b/benchmarks/xlmr/ootb/xlmr_parser.py
@@ -1,0 +1,41 @@
+import argparse
+import json
+
+"""
+Parse inputs for the XLMR benchmark
+"""
+
+def parse_seqlen_dist(seqlen_dist_str):
+    seqlen_dist_json = json.loads(seqlen_dist_str)
+
+    # assert that it is in the right format (percentiles and integers)
+
+    return seqlen_dist_json
+
+
+def init_argparse() -> argparse.ArgumentParser:
+    """
+    Returns a parser that can parse the given inputs by calling parser.parse_args()
+    
+    Some types are functions - this is because argparse under the hood just calls the type on the input string. 
+    Eg if type=int, then if you get a str="123", argparse calls int("123")->123. 
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark XLM-R model"
+    )
+    parser.add_argument("--logdir", type=str, default=None)
+    parser.add_argument("--inference-only", action="store_true", default=False)
+    parser.add_argument("--famconfig", type=str, default="tiny")
+    parser.add_argument("--use-gpu", action="store_true", default=False)
+    parser.add_argument("--num-batches", type=int, default=10) # num batches to benchmark 
+    parser.add_argument("--warmup-batches", type=int, default=0) # num batches to warmup
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--sequence-length", type=int, default=64) 
+    parser.add_argument("--vocab-size", type=int, default=250000)
+    parser.add_argument("--half-model", action="store_true", default=False)
+    parser.add_argument('--seqlen-dist', type=str, default=None) # sequence length distribution. Type is string in JSON format. 
+    parser.add_argument('--seqlen-dist-max', type=int, default=256) # maximum allowed sequence length
+    
+    return parser
+

--- a/benchmarks/xlmr/ootb/xlmr_utils.py
+++ b/benchmarks/xlmr/ootb/xlmr_utils.py
@@ -1,0 +1,47 @@
+
+import numpy as np
+
+"""
+Util functions for xlmr benchmark
+"""
+
+def is_monotonic_increasing(x):
+    dx = np.diff(x)
+    return np.all(dx >= 0)
+
+def query_from_percentile_distribution(query_percentile, sorted_percentiles_lst, sorted_values_lst):
+    """
+    Query from a percentile distribution.
+
+    Example: 
+    query_percentile = 0.6
+    sorted_percentiles_lst = [0, 0.4, 0.8, 1.0]
+    sorted_values_lst = [12, 15, 72, 105]
+    The query percentile lies right in the middle between p40 (0.4) and p80 (0.8). 
+    Thus we linearly interpolate between the two, and get p60 -> (15 + 72) / 2 = 43.5. 
+    """
+
+    assert len(sorted_percentiles_lst) == sorted_values_lst
+    assert 0 <= query_percentile <= 1
+    assert is_monotonic_increasing(sorted_values_lst) 
+    assert is_monotonic_increasing(sorted_percentiles_lst) 
+
+    ret_val = None
+    for i, p in enumerate(sorted_percentiles_lst):
+        if(query_percentile == p):
+            ret_val = sorted_values_lst[i] 
+            break
+        if(query_percentile < p):
+            # linearly interpolate between i and i-1th percentile to get right value
+            low_p, low_val = sorted_percentiles_lst[i-1], sorted_values_lst[i]
+            high_p, high_val = p, sorted_values_lst[i]
+            percentile_in_bucket = (query_percentile - low_p) / (high_p - low_p)
+            diff_from_low = percentile_in_bucket * (high_val - low_val)
+            ret_val = diff_from_low + low_val 
+            break
+    
+    if(ret_val is None):
+        # Should never reach here. Asserts should keep input correct so above logic doesn't fail. 
+        raise Exception('ret_val should not be None. Should never reach here.')
+    
+    return ret_val

--- a/benchmarks/xlmr/ootb/xlmr_utils.py
+++ b/benchmarks/xlmr/ootb/xlmr_utils.py
@@ -21,7 +21,7 @@ def query_from_percentile_distribution(query_percentile, sorted_percentiles_lst,
     Thus we linearly interpolate between the two, and get p60 -> (15 + 72) / 2 = 43.5. 
     """
 
-    assert len(sorted_percentiles_lst) == sorted_values_lst
+    assert len(sorted_percentiles_lst) == len(sorted_values_lst)
     assert 0 <= query_percentile <= 1
     assert is_monotonic_increasing(sorted_values_lst) 
     assert is_monotonic_increasing(sorted_percentiles_lst) 

--- a/benchmarks/xlmr/ootb/xlmr_utils.py
+++ b/benchmarks/xlmr/ootb/xlmr_utils.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 """
-Util functions for xlmr benchmark
+Util functions for XLM-R benchmark
 """
 
 def is_monotonic_increasing(x):


### PR DESCRIPTION
Major update to XLMR, with the following components
1. Restructuring of the XLMR benchmark into xlmr.py (main benchmark), xlmr_data.py (synthetic data generation), xlmr_utils.py (util functions), xlmr_parser.py (command line args parser). 
2. Creation of the sample_sequence_length(), which allows one to sample from a distribution of sequence lengths. This means the synthetic input data can be more closely matched to a real world use-case's data distribution. 
3. Switching from xlmr.model(input) to xlmr.extract_features(input). The difference: the former outputs tensors of shape (batch_size, seq_len, vocab_size) and the latter ouputs shape of (batch_size, seq_len, embedding_size). Typically vocab size is huge, like 250k, while embedding size is 1k, which means new output is much smaller. This is also more accurate to real use cases - typically we care about getting the embeddings from the last encoder layer like in the latter case, not getting the probability (really logits, but same diff) of every possible token in the vocabulary being in the input sequences.
4. Fixing of a memory leak that caused GPU OOMs by calling del on the output tensors from the model's forward and backwards pass. See more in this [comment](https://github.com/facebookresearch/FAMBench/pull/70/files?authenticity_token=rtFV0c9e35WhYv1goGHviMnh3Ow7abuIcO8hO8qHyX0MVi9zLIAEBn9HM8yA67oNW3JstTuTyJhvp6faupsPSw%3D%3D&file-filters%5B%5D=.py#r769141498) on this PR.