### PR TITLE
Add multi-node compatibility to dlrm comms ubenches.

### DIFF
--- a/benchmarks/dlrm/ubench/dlrm_ubench_comms_driver.py
+++ b/benchmarks/dlrm/ubench/dlrm_ubench_comms_driver.py
@@ -27,6 +27,11 @@ def get_local_rank():
 def main():
     parser = argparse.ArgumentParser(description="comms.py driver")
     parser.add_argument(
+        "--master_ip",
+        type=str,
+        default="localhost",
+    )
+    parser.add_argument(
         "--size",
         type=str,
         default="small",
@@ -65,7 +70,6 @@ def main():
     (x, y) = (args.size, lookup.get(args.size, args.size))
     (size, name) = (x, y) if args.size.isdigit() else (y, x)
 
-    master_ip = "localhost"
     num_compute_per_collective = 100
     mm_dim = 1000
     num_iter = 100
@@ -73,7 +77,7 @@ def main():
     cmd = f"""
         --f 2
         --n {num_iter}
-        --master-ip {master_ip}
+        --master-ip {args.master_ip}
         --master-port 22565
         --collective {args.collective}
         --b {size}

--- a/benchmarks/dlrm/ubench/dlrm_ubench_comms_driver.py
+++ b/benchmarks/dlrm/ubench/dlrm_ubench_comms_driver.py
@@ -13,10 +13,10 @@ import comms_utils
 from comms import main as comms_main
 
 # FB5 Logger
-p = pathlib.Path(__file__).parent.resolve() / "../../../fb5logging"
+p = pathlib.Path(__file__).parent.resolve() / "../../../bmlogging"
 sys.path.append(fspath(p))
 import loggerconstants
-from fb5logger import FB5Logger
+from bmlogger import get_bmlogger
 
 
 def get_local_rank():
@@ -85,10 +85,11 @@ def main():
         --num-compute {num_compute_per_collective}
         --mm-dim {mm_dim}
         --backend {args.backend}
+        --device cuda
     """
-    sys.argv = cmd.replace("\n", " ").replace("  ", "").split()
+    sys.argv = cmd.split()
 
-    fb5logger = FB5Logger(args.fb5logger)
+    fb5logger = get_bmlogger(args.fb5logger)
     fb5logger.header(
         "DLRM",
         "UBENCH",

--- a/benchmarks/run_dlrm_ubench_train_allreduce.sh
+++ b/benchmarks/run_dlrm_ubench_train_allreduce.sh
@@ -48,6 +48,7 @@ LOGGER_FILE="${LOG_DIR}/${benchmark}_${implementation}_${mode}_${collective}_${s
 
 get_local_rank=$(echo "python3 -c 'import dlrm.ubench.dlrm_ubench_comms_driver as comms; print(comms.get_local_rank())'")
 rank=$(eval $get_local_rank | head -n 1)
+master_ip="${5:-localhost}"
 
 if [ $rank -eq 0 ]; then
   echo "=== Launching FB5 ==="
@@ -60,7 +61,7 @@ if [ $rank -eq 0 ]; then
   echo "Running Command:"
 fi
 
-(set -x; python3 "${benchmark}/${implementation}/dlrm_ubench_comms_driver.py" --fb5logger=${LOGGER_FILE} --collective=all_reduce --size=${size} 2>&1)
+(set -x; python3 "${benchmark}/${implementation}/dlrm_ubench_comms_driver.py" --master_ip=${master_ip} --fb5logger=${LOGGER_FILE} --collective=all_reduce --size=${size} 2>&1)
 
 if [ $rank -eq 0 ]; then
   echo "=== Completed Run ==="

--- a/benchmarks/run_dlrm_ubench_train_alltoall.sh
+++ b/benchmarks/run_dlrm_ubench_train_alltoall.sh
@@ -48,6 +48,7 @@ LOGGER_FILE="${LOG_DIR}/${benchmark}_${implementation}_${mode}_${collective}_${s
 
 get_local_rank=$(echo "python3 -c 'import dlrm.ubench.dlrm_ubench_comms_driver as comms; print(comms.get_local_rank())'")
 rank=$(eval $get_local_rank | head -n 1)
+master_ip="${5:-localhost}"
 
 if [ $rank -eq 0 ]; then
   echo "=== Launching FB5 ==="
@@ -60,7 +61,7 @@ if [ $rank -eq 0 ]; then
   echo "Running Command:"
 fi
 
-(set -x; python3 "${benchmark}/${implementation}/dlrm_ubench_comms_driver.py" --fb5logger=${LOGGER_FILE} --collective=all_to_all --size=${size} 2>&1)
+(set -x; python3 "${benchmark}/${implementation}/dlrm_ubench_comms_driver.py" --master_ip=${master_ip} --fb5logger=${LOGGER_FILE} --collective=all_to_all --size=${size} 2>&1)
 
 if [ $rank -eq 0 ]; then
   echo "=== Completed Run ==="


### PR DESCRIPTION
Example run:
$ mpirun -x FI_PROVIDER="efa" -x FI_EFA_USE_DEVICE_RDMA=1 -x NCCL_DEBUG=INFO  --hostfile ~/hosts -np 32 -N 8 --mca pml ^cm --mca btl tcp,self --bind-to none ./run_dlrm_ubench_train_alltoall.sh -l results -c 544000000 $(hostname -i)

(This was tested on 4 ec2 p4d.24xlarge instances running Ubuntu 20.04.)
