### PR TITLE
Update LR default value in run_cvt_train.sh

### DIFF
--- a/benchmarks/cvt/ootb/run_cvt_train.sh
+++ b/benchmarks/cvt/ootb/run_cvt_train.sh
@@ -4,6 +4,7 @@ set -ex
 
 GPUS=${1:-8}
 BS=${2:-256}
+LR=${3:-0.000125}
 
 export NODE_COUNT=${NODE_COUNT:=1}
 export RANK=${RANK:=0}
@@ -18,7 +19,7 @@ LOG_FILE=${OUTPUT_DIR}/cvt_${NODE_COUNT}x${GPUS}x${BS}.log
 
 bash run-alt.sh -g ${GPUS} -t train --cfg experiments/imagenet/cvt/cvt-13-224x224.yaml \
     DATASET.ROOT ../DATASET/imagenet OUTPUT_DIR ${OUTPUT_DIR} \
-    TRAIN.END_EPOCH 300 TRAIN.BATCH_SIZE_PER_GPU ${BS} 2>&1 | tee ${LOG_FILE}
+    TRAIN.END_EPOCH 300 TRAIN.BATCH_SIZE_PER_GPU ${BS} TRAIN.LR ${LR} 2>&1 | tee ${LOG_FILE}
 
 cd ${OUTPUT_DIR}
 python ../cvt_parser.py --logpath ${LOG_FILE} --steps $[${GPUS}*10]


### PR DESCRIPTION
Introduces LR variable in run_cvt_train.sh and sets the default LR to be 0.000125.

NaNs are observed when running the default test case with a lower batch size (bs=128) as previously noted before in https://github.com/microsoft/CvT/issues/4#issuecomment-855193111. This PR introduces a variable to control the LR and reduces the learning rate to avoid NaN observations for the 16 GPU test case.