### PR TITLE
Disable SCALE_LR in CvT

### DIFF
--- a/benchmarks/cvt/ootb/run_cvt_train.sh
+++ b/benchmarks/cvt/ootb/run_cvt_train.sh
@@ -5,6 +5,7 @@ set -ex
 GPUS=${1:-8}
 BS=${2:-256}
 LR=${3:-0.000125}
+SCALE_LR=${4:-False}
 
 export NODE_COUNT=${NODE_COUNT:=1}
 export RANK=${RANK:=0}
@@ -19,7 +20,8 @@ LOG_FILE=${OUTPUT_DIR}/cvt_${NODE_COUNT}x${GPUS}x${BS}.log
 
 bash run-alt.sh -g ${GPUS} -t train --cfg experiments/imagenet/cvt/cvt-13-224x224.yaml \
     DATASET.ROOT ../DATASET/imagenet OUTPUT_DIR ${OUTPUT_DIR} \
-    TRAIN.END_EPOCH 300 TRAIN.BATCH_SIZE_PER_GPU ${BS} TRAIN.LR ${LR} 2>&1 | tee ${LOG_FILE}
+    TRAIN.END_EPOCH 300 TRAIN.BATCH_SIZE_PER_GPU ${BS} TRAIN.LR ${LR} \
+    TRAIN.SCALE_LR ${SCALE_LR} 2>&1 | tee ${LOG_FILE}
 
 cd ${OUTPUT_DIR}
 python ../cvt_parser.py --logpath ${LOG_FILE} --steps $[${GPUS}*10]


### PR DESCRIPTION
NaN's are produced in CvT model at large number of devices (>64 GPUs) due to the scaling LR. This PR disables the scaling LR by default for benchmark purposes.

Previously we reduced the overall LR to alleviate this issue https://github.com/facebookresearch/FAMBench/commit/58f68431660fd84d1b7fdcaa4b6925dc12fb3bd3 but large learning rate still becomes an issue when the world size is large.
