### PR TITLE
fix dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py

### DIFF
--- a/benchmarks/dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py
+++ b/benchmarks/dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py
@@ -108,7 +108,6 @@ def run_emb(args, run_dataset):
         L,
         E,
         alpha=args.alpha,
-        weights_precision=args.weights_precision,
         weighted=args.weighted,
     )
     if isIntNTableBatched:


### PR DESCRIPTION
fix `dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py` due to the API change in FBGEMM.
https://github.com/pytorch/FBGEMM/commit/4c581375
Fixes https://github.com/facebookresearch/FAMBench/issues/111