### PR TITLE
Set num workers to 0 for rnnt single gpu run

### DIFF
--- a/benchmarks/rnnt/ootb/train/scripts/train.sh
+++ b/benchmarks/rnnt/ootb/train/scripts/train.sh
@@ -61,6 +61,7 @@ export OMP_NUM_THREADS=1
 : ${CLIP_NORM:=1}
 
 BATCH_SIZE=$(( $GLOBAL_BATCH_SIZE / $NUM_GPUS ))
+NUM_WORKERS=$(( NUM_GPUS == 1 ? 0 : NUM_GPUS ))
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -87,6 +88,7 @@ ARGS+=" --grad_accumulation_steps=$GRAD_ACCUMULATION_STEPS "
 ARGS+=" --device=$DEVICE"
 ARGS+=" --beta1=$BETA1"
 ARGS+=" --beta2=$BETA2"
+ARGS+=" --num-workers=${NUM_WORKERS}"
 
 [ -n "$FB5LOGGER" ] &&               ARGS+=" --fb5logger=$FB5LOGGER"
 [ -n "$FB5CONFIG" ] &&               ARGS+=" --fb5config=$FB5CONFIG"
@@ -109,7 +111,7 @@ ARGS+=" --beta2=$BETA2"
 [ -n "$WEIGHTS_INIT_SCALE" ] &&      ARGS+=" --weights_init_scale=$WEIGHTS_INIT_SCALE"
 [ -n "$MAX_SYMBOL_PER_SAMPLE" ] &&  ARGS+=" --max_symbol_per_sample=$MAX_SYMBOL_PER_SAMPLE"
 
-DISTRIBUTED=${DISTRIBUTED:-"-m torch.distributed.launch --nproc_per_node=$NUM_GPUS"}
+[ $NUM_GPUS -gt 1 ] &&    DISTRIBUTED=${DISTRIBUTED:-"-m torch.distributed.launch --nproc_per_node=$NUM_GPUS"}
 script_dir=`dirname "${BASH_SOURCE[0]}"`
 set -x
 python ${DISTRIBUTED} "$script_dir/../train.py" ${ARGS}

--- a/benchmarks/rnnt/ootb/train/scripts/train.sh
+++ b/benchmarks/rnnt/ootb/train/scripts/train.sh
@@ -88,7 +88,7 @@ ARGS+=" --grad_accumulation_steps=$GRAD_ACCUMULATION_STEPS "
 ARGS+=" --device=$DEVICE"
 ARGS+=" --beta1=$BETA1"
 ARGS+=" --beta2=$BETA2"
-ARGS+=" --num-workers=${NUM_WORKERS}"
+ARGS+=" --num-workers=$NUM_WORKERS"
 
 [ -n "$FB5LOGGER" ] &&               ARGS+=" --fb5logger=$FB5LOGGER"
 [ -n "$FB5CONFIG" ] &&               ARGS+=" --fb5config=$FB5CONFIG"

--- a/benchmarks/rnnt/ootb/train/train.py
+++ b/benchmarks/rnnt/ootb/train/train.py
@@ -373,6 +373,7 @@ def main():
             num_replicas=world_size,
             rank=args.local_rank,
             num_workers=args.num_workers,
+            prefetch_factor=None,
             device_type=args.device)
 
         val_loader = AudioDataLoader(
@@ -386,6 +387,7 @@ def main():
             num_replicas=world_size,
             rank=args.local_rank,
             num_workers=args.num_workers,
+            prefetch_factor=None,
             device_type=args.device)
 
     train_feat_proc = train_augmentations

--- a/benchmarks/rnnt/ootb/train/train.py
+++ b/benchmarks/rnnt/ootb/train/train.py
@@ -73,6 +73,7 @@ def parse_args():
     training.add_argument('--target', default=0.058, type=float, help='Target WER accuracy')
     training.add_argument('--weights_init_scale', default=0.5, type=float, help='If set, overwrites value in config.')
     training.add_argument('--hidden_hidden_bias_scale', type=float, help='If set, overwrites value in config.')
+    training.add_argument('--prefetch_factor', default=None, type=int, help='Prefetch Factor for Audio Data Loader')
 
     optim = parser.add_argument_group('optimization setup')
     #optim.add_argument('--sample-rate', default=16000, type=int, help='Sample rate')
@@ -373,7 +374,7 @@ def main():
             num_replicas=world_size,
             rank=args.local_rank,
             num_workers=args.num_workers,
-            prefetch_factor=None,
+            prefetch_factor=args.prefetch_factor,
             device_type=args.device)
 
         val_loader = AudioDataLoader(
@@ -387,7 +388,7 @@ def main():
             num_replicas=world_size,
             rank=args.local_rank,
             num_workers=args.num_workers,
-            prefetch_factor=None,
+            prefetch_factor=args.prefetch_factor,
             device_type=args.device)
 
     train_feat_proc = train_augmentations


### PR DESCRIPTION
This PR has changes to set num_workers to 0 for rnnt single gpu runs. This change helped improve performance on ROCm.