### PR TITLE
Change torch.distributed.launch to torchrun for RNNT

### DIFF
--- a/benchmarks/rnnt/ootb/train/scripts/train.sh
+++ b/benchmarks/rnnt/ootb/train/scripts/train.sh
@@ -109,7 +109,7 @@ ARGS+=" --beta2=$BETA2"
 [ -n "$WEIGHTS_INIT_SCALE" ] &&      ARGS+=" --weights_init_scale=$WEIGHTS_INIT_SCALE"
 [ -n "$MAX_SYMBOL_PER_SAMPLE" ] &&  ARGS+=" --max_symbol_per_sample=$MAX_SYMBOL_PER_SAMPLE"
 
-DISTRIBUTED=${DISTRIBUTED:-"-m torch.distributed.launch --nproc_per_node=$NUM_GPUS"}
+DISTRIBUTED=${DISTRIBUTED:-"--nproc_per_node=$NUM_GPUS"}
 script_dir=`dirname "${BASH_SOURCE[0]}"`
 set -x
-python ${DISTRIBUTED} "$script_dir/../train.py" ${ARGS}
+torchrun ${DISTRIBUTED} "$script_dir/../train.py" ${ARGS}


### PR DESCRIPTION
This PR has changes to move from torch.distributed.launch to torchrun for RNNT. torch.distributed.launch is deprecated and could cause errors in the future, this change helps fix that.
