### PR TITLE
Revert num-workers patch for rnnt

### DIFF
--- a/benchmarks/rnnt/ootb/train/scripts/train.sh
+++ b/benchmarks/rnnt/ootb/train/scripts/train.sh
@@ -61,7 +61,6 @@ export OMP_NUM_THREADS=1
 : ${CLIP_NORM:=1}
 
 BATCH_SIZE=$(( $GLOBAL_BATCH_SIZE / $NUM_GPUS ))
-NUM_WORKERS=$(( NUM_GPUS == 1 ? 0 : NUM_GPUS ))
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -88,7 +87,6 @@ ARGS+=" --grad_accumulation_steps=$GRAD_ACCUMULATION_STEPS "
 ARGS+=" --device=$DEVICE"
 ARGS+=" --beta1=$BETA1"
 ARGS+=" --beta2=$BETA2"
-ARGS+=" --num-workers=$NUM_WORKERS"
 
 [ -n "$FB5LOGGER" ] &&               ARGS+=" --fb5logger=$FB5LOGGER"
 [ -n "$FB5CONFIG" ] &&               ARGS+=" --fb5config=$FB5CONFIG"


### PR DESCRIPTION
RNN-T has a num-workers patch added recently to improve ROCm performance. The perf improvements are done in ROCm libraries and this patch is no longer needed. This PR has changes to revert it.