### PR TITLE
CvT update for torchrun

### DIFF
--- a/benchmarks/cvt/ootb/run_cvt_train.sh
+++ b/benchmarks/cvt/ootb/run_cvt_train.sh
@@ -4,8 +4,9 @@ set -ex
 
 GPUS=${1:-8}
 BS=${2:-256}
-LR=${3:-0.000125}
-SCALE_LR=${4:-False}
+END_EPOCH=${3:-300}
+LR=${4:-0.000125}
+SCALE_LR=${5:-False}
 
 export NODE_COUNT=${NODE_COUNT:=1}
 export RANK=${RANK:=0}
@@ -20,7 +21,7 @@ LOG_FILE=${OUTPUT_DIR}/cvt_${NODE_COUNT}x${GPUS}x${BS}.log
 
 bash run-alt.sh -g ${GPUS} -t train --cfg experiments/imagenet/cvt/cvt-13-224x224.yaml \
     DATASET.ROOT ../DATASET/imagenet OUTPUT_DIR ${OUTPUT_DIR} \
-    TRAIN.END_EPOCH 300 TRAIN.BATCH_SIZE_PER_GPU ${BS} TRAIN.LR ${LR} \
+    TRAIN.END_EPOCH ${END_EPOCH} TRAIN.BATCH_SIZE_PER_GPU ${BS} TRAIN.LR ${LR} \
     TRAIN.SCALE_LR ${SCALE_LR} 2>&1 | tee ${LOG_FILE}
 
 cd ${OUTPUT_DIR}


### PR DESCRIPTION
CvT repo has changes to run with torchrun instead of torch.distributed.launch. This PR pins CvT to include those.

It also has changes to pull out END_EPOCH as a parameter user can control through their scripts.