### PR TITLE
Pointing to pinned mmcv version

### DIFF
--- a/benchmarks/bevt/ootb/Dockerfile.rocm
+++ b/benchmarks/bevt/ootb/Dockerfile.rocm
@@ -15,7 +15,7 @@ RUN git clone https://github.com/ROCmSoftwarePlatform/apex && \
     cd ..  && rm apex -r
 
 # Install mmcv from source. Cherry-picking a fix.
-RUN git clone https://github.com/open-mmlab/mmcv && \
+RUN git clone -b bevt_branch https://github.com/zstreet87/mmcv && \
     cd mmcv && \
     pip install -r requirements/optional.txt && \
     git config user.email user@example.com && \

--- a/benchmarks/bevt/ootb/Dockerfile.rocm
+++ b/benchmarks/bevt/ootb/Dockerfile.rocm
@@ -15,7 +15,7 @@ RUN git clone https://github.com/ROCmSoftwarePlatform/apex && \
     cd ..  && rm apex -r
 
 # Install mmcv from source. Cherry-picking a fix.
-RUN git clone -b bevt_branch https://github.com/zstreet87/mmcv && \
+RUN git clone -b rocm-pinn https://github.com/zstreet87/mmcv && \
     cd mmcv && \
     pip install -r requirements/optional.txt && \
     git config user.email user@example.com && \

--- a/benchmarks/bevt/ootb/run_bevt_train.sh
+++ b/benchmarks/bevt/ootb/run_bevt_train.sh
@@ -49,7 +49,7 @@ if [ -f ${work_dir}/latest.pth ]; then rm ${work_dir}/*.pth; fi
 
 (
     set -x
-    python -m torch.distributed.launch --nnodes ${NODE_COUNT} \
+    torchrun --nnodes ${NODE_COUNT} \
         --node_rank ${RANK} \
         --master_addr ${MASTER_ADDR} \
         --master_port ${MASTER_PORT} \


### PR DESCRIPTION
MMCV has had major refactors splitting into MMEngine etc.  As BEVT isn't maintained anymore, recommendation is to pull from another mmcv that has rocm specific patches on top but has the same old API BEVT is expecting.

One thing to note, this dockerfile should be tested. Building apex is not needed if using rocm/pytorch;latest as base image at the time of creating this PR.