### PR TITLE
Fix typo in README mlcommons/training

### DIFF
--- a/benchmarks/rnnt/ootb/train/README.md
+++ b/benchmarks/rnnt/ootb/train/README.md
@@ -7,7 +7,7 @@ Speech recognition accepts raw audio samples and produces a corresponding text t
 ### From Docker
 1. Clone the repository
 ```
-git clone https://github.com/mlcommon/training.git
+git clone https://github.com/mlcommons/training.git
 ```
 2. Install CUDA and Docker
 ```


### PR DESCRIPTION
mlcommon/training.git points to a random repository. This should actually be mlcommons/training. This was reported in a Meta Bug Bounty report.