### PR TITLE
fix dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py

### DIFF
--- a/benchmarks/dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py
+++ b/benchmarks/dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py
@@ -115,7 +115,8 @@ def run_emb(args, run_dataset):
     warmup_requests, requests = requests[:args.warmups], requests[args.warmups:]
 
     #warmups
-    for (indices, offsets, weights) in warmup_requests:
+    for request in warmup_requests:
+        (indices, offsets, weights) = request.unpack_3()
         emb.forward(indices, offsets, weights)
 
     # forward


### PR DESCRIPTION
fix dlrm/ubench/dlrm_ubench_train_embeddingbag_driver.py due to the changes in FBGEMM https://github.com/ROCm/FBGEMM/blame/d5b7155aed3af8b26b90a2aba2485c2562809df3/fbgemm_gpu/fbgemm_gpu/tbe/utils/requests.py#L40